### PR TITLE
Use prop-types instead of referencing React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.6.2",
     "express": "^4.13.4",
+    "prop-types": "^15.6.0",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "webpack": "^1.12.2",

--- a/src/react-google-picker.js
+++ b/src/react-google-picker.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import loadScript from 'load-script';
 
 const GOOGLE_SDK_URL = 'https://apis.google.com/js/api.js';
@@ -8,18 +9,18 @@ let scriptLoadingStarted = false;
 export default class GoogleChooser extends React.Component {
 
     static propTypes = {
-        children: React.PropTypes.node,
-        clientId: React.PropTypes.string.isRequired,
-        developerKey: React.PropTypes.string.isRequired,
-        scope: React.PropTypes.array,
-        viewId: React.PropTypes.string,
-        authImmediate: React.PropTypes.bool,
-        origin: React.PropTypes.string,
-        onChange: React.PropTypes.func,
-        createPicker: React.PropTypes.func,
-        multiselect: React.PropTypes.bool,
-        navHidden: React.PropTypes.bool,
-        disabled: React.PropTypes.bool
+        children: PropTypes.node,
+        clientId: PropTypes.string.isRequired,
+        developerKey: PropTypes.string.isRequired,
+        scope: PropTypes.array,
+        viewId: PropTypes.string,
+        authImmediate: PropTypes.bool,
+        origin: PropTypes.string,
+        onChange: PropTypes.func,
+        createPicker: PropTypes.func,
+        multiselect: PropTypes.bool,
+        navHidden: PropTypes.bool,
+        disabled: PropTypes.bool
   };
 
   static defaultProps = {


### PR DESCRIPTION
React.PropTypes is deprecated.  https://reactjs.org/warnings/dont-call-proptypes.html